### PR TITLE
Support for different build destination than default

### DIFF
--- a/lib/jekyll/hooks/purgecss.rb
+++ b/lib/jekyll/hooks/purgecss.rb
@@ -7,7 +7,7 @@ Jekyll::Hooks.register(:site, :post_write) do |site|
     raise PurgecssRuntimeError unless system(
       "./node_modules/.bin/purgecss " \
       "--config ./purgecss.config.js " \
-      "--out _site/#{site.config.fetch("css_dir", "css")}/"
+      "--out #{site.destination}/#{site.config.fetch("css_dir", "css")}/"
     )
   end
 end


### PR DESCRIPTION
Retrieve from _config.yml the build destination or use use the default '_site', if no 'destination' setting exists.