### PR TITLE
Support for alternative Jekyll build destination

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add your Purgecss configuration to a `purgecss.config.js` file in the root of yo
 ```javascript
 // purgecss.config.js
 
-module.exports {
+module.exports = {
   // These are the files that Purgecss will search through
   content: ["./_site/**/*.html"],
 

--- a/lib/jekyll/hooks/purgecss.rb
+++ b/lib/jekyll/hooks/purgecss.rb
@@ -7,7 +7,7 @@ Jekyll::Hooks.register(:site, :post_write) do |site|
     raise PurgecssRuntimeError unless system(
       "./node_modules/.bin/purgecss " \
       "--config ./purgecss.config.js " \
-      "--out _site/#{site.config.fetch("css_dir", "css")}/"
+      "--out #{site.config.fetch("destination")}/#{site.config.fetch("css_dir", "css")}/"
     )
   end
 end


### PR DESCRIPTION
If a 'destination' value is configured on '_config.yml', it will be retrieved and the CSS output directed to said directory.
Otherwise, it defaults to '_site'.

Sorry for the pull requests repetition. On the previous pull request I had placed the wrong code in it.